### PR TITLE
refactor: Uses a single message when Data Layers aren't found.

### DIFF
--- a/src/full-report/components/DataLayers/CustomLayers.jsx
+++ b/src/full-report/components/DataLayers/CustomLayers.jsx
@@ -46,17 +46,7 @@ const CustomLayers = ({ layers, theme }) => {
     );
   }
 
-  return (
-    <div
-      style={{
-        textAlign: 'center',
-        padding: '20px',
-      }}
-    >
-      <h4>Custom data layers</h4>
-      No custom data layers found. Track custom data layers <a href="#" onClick={() => chrome.runtime.openOptionsPage()}>in the options.</a>
-    </div>
-  );
+  return <span />;
 };
 
 CustomLayers.propTypes = {

--- a/src/full-report/components/DataLayers/DataLayers.jsx
+++ b/src/full-report/components/DataLayers/DataLayers.jsx
@@ -36,6 +36,7 @@ export default class DataLayers extends Component {
     const defaultLayers = this.layers.filter(layer => layer.type !== 'userDefined');
     const userLayers = this.layers.filter(layer => layer.type === 'userDefined');
     let downloadButton = '';
+    let content;
 
     if (this.layers.length > 0) {
       downloadButton = (
@@ -46,6 +47,27 @@ export default class DataLayers extends Component {
           hoverColor="#183063"
           className="yellowMhButton"
         />
+      );
+
+      content = (
+        <Paper zDepth={1} style={{ padding: '20px' }}>
+          <DefaultLayers layers={defaultLayers} theme={monokaiTheme} />
+          <CustomLayers layers={userLayers} theme={monokaiTheme} />
+        </Paper>
+      );
+    } else {
+      content = (
+        <Paper zDepth={1} style={{ padding: '20px' }}>
+          <div
+            style={{
+              textAlign: 'center',
+              padding: '20px',
+            }}
+          >
+            <h3>No data layers found.</h3>
+            Track custom data layers <a href="#" onClick={() => chrome.runtime.openOptionsPage()}>in the options.</a>
+          </div>
+        </Paper>
       );
     }
 
@@ -59,10 +81,7 @@ export default class DataLayers extends Component {
             {downloadButton}
           </div>
         </div>
-        <Paper zDepth={1} style={{ padding: '20px' }}>
-          <DefaultLayers layers={defaultLayers} theme={monokaiTheme} />
-          <CustomLayers layers={userLayers} theme={monokaiTheme} />
-        </Paper>
+        {content}
       </div>
     );
   }

--- a/src/full-report/components/DataLayers/DefaultLayers.jsx
+++ b/src/full-report/components/DataLayers/DefaultLayers.jsx
@@ -24,16 +24,7 @@ const LayersList = ({ layers, theme }) => {
     );
   }
 
-  return (
-    <div
-      style={{
-        textAlign: 'center',
-        padding: '20px',
-      }}
-    >
-      <h3>No data layers found.</h3>
-    </div>
-  );
+  return <span />;
 };
 
 LayersList.propTypes = {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -10,6 +10,10 @@ html, body {
   font-family: 'Roboto', Arial, sans-serif;
 }
 
+a {
+  color: $mh-blue;
+}
+
 .center {
   margin: 0 auto;
   text-align: center;


### PR DESCRIPTION
Previously, the task of displaying a "not found" message fell to both default and custom Data Layer
components. However, this can produce a confusing UI. This update utilizes a single message if no
DLs are found for both types.

Closes #47 