### PR TITLE
refactor: Disables the ripple effect for Material UI

### DIFF
--- a/src/config/theme.config.js
+++ b/src/config/theme.config.js
@@ -40,6 +40,15 @@ const popupAppTheme = {
   inkBar: {
     backgroundColor: mhYellow,
   },
+  ripple: {
+    color: 'transparent',
+  },
+};
+
+const fullReportTheme = {
+  ripple: {
+    color: 'transparent',
+  },
 };
 
 export {

--- a/src/full-report/report.jsx
+++ b/src/full-report/report.jsx
@@ -1,18 +1,20 @@
 import * as queryString from 'query-string';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';
 // Import App CSS
 import '../styles/index.scss';
+import { fullReportTheme } from '../config/theme.config';
 
 import * as util from '../chrome.utils';
 
 const parsedQuery = queryString.parse(window.location.search);
 
 ReactDOM.render(
-  <MuiThemeProvider>
+  <MuiThemeProvider muiTheme={getMuiTheme(fullReportTheme)}>
     <App
       tabConnection={util.tabConnection}
       tabId={parsedQuery.id}


### PR DESCRIPTION
I don't see an issue for this, but here's the refactor we discussed @mrezo. This disables the "ripple" effect on buttons in MaterialUI.