### PR TITLE
Adds the protocol of a request to the Navigation Path in Full Report

### DIFF
--- a/src/full-report/components/NavigationPath.jsx
+++ b/src/full-report/components/NavigationPath.jsx
@@ -12,6 +12,8 @@ const NavigationPath = ({ navigationPath }) => (
       {navigationPath.redirects.map((redirect) => {
         const requestKey = `navPath-${redirect.data.requestId}-${redirect.data.timeStamp}`;
         const tooltipId = `${requestKey}-tooltip`;
+        const { protocol, host, pathname } = redirect.parsedUrl;
+        const url = `${protocol}//${host + pathname}`;
         return (
           <li className="redirect clearfix" key={requestKey}>
             <div
@@ -38,7 +40,7 @@ const NavigationPath = ({ navigationPath }) => (
                   parsedUrl={redirect.parsedUrl}
                 />
               </ReactTooltip>
-              <div className="url">{redirect.parsedUrl.host + redirect.parsedUrl.pathname}</div>
+              <div className="url">{url}</div>
             </div>
             <div
               style={{
@@ -71,7 +73,9 @@ const NavigationPath = ({ navigationPath }) => (
             parsedUrl={navigationPath.final.parsedUrl}
           />
         </ReactTooltip>
-        <div className="url">{navigationPath.final.parsedUrl.host + navigationPath.final.parsedUrl.pathname}</div>
+        <div className="url">
+          {`${navigationPath.final.parsedUrl.protocol}//${navigationPath.final.parsedUrl.host + navigationPath.final.parsedUrl.pathname}`}
+        </div>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Closes #49 

**Preview**:

<img width="386" alt="mightyhive_analytics_tracker" src="https://user-images.githubusercontent.com/4984283/33536940-4a2b554c-d86d-11e7-8650-5f6ceb8bf556.png">
